### PR TITLE
Fix EXP drops and add missing log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20-R0.1-SNAPSHOT</version>
+            <version>1.21.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/otavio/treefella/TreeFella.java
+++ b/src/main/java/me/otavio/treefella/TreeFella.java
@@ -1,11 +1,14 @@
 package me.otavio.treefella;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import me.otavio.treefella.files.PlacedBlocks;
 import me.otavio.treefella.listeners.BlockBreakEvent;
 import me.otavio.treefella.listeners.BlockPlaceEvent;
 import org.bukkit.Material;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.entity.ExperienceOrb;
+import java.util.Objects;
 
 public final class TreeFella extends JavaPlugin {
 
@@ -19,7 +22,8 @@ public final class TreeFella extends JavaPlugin {
             Material.DARK_OAK_LOG,
             Material.CHERRY_LOG,
             Material.WARPED_STEM,
-            Material.CRIMSON_STEM
+            Material.CRIMSON_STEM,
+            Material.PALE_OAK_LOG
     );
 
     public static final ImmutableList<Material> ORES = ImmutableList.of(
@@ -43,6 +47,40 @@ public final class TreeFella extends JavaPlugin {
             Material.NETHER_GOLD_ORE,
             Material.ANCIENT_DEBRIS
     );
+
+    private static final ImmutableMap.Builder<Material, OreXP> ORES_XP_raw = ImmutableMap.<Material, OreXP>builder()
+            .put(Material.COAL_ORE, new OreXP(0, 2))
+            .put(Material.DEEPSLATE_COAL_ORE, new OreXP(0, 2))
+            .put(Material.NETHER_GOLD_ORE, new OreXP(0,1))
+            .put(Material.DIAMOND_ORE, new OreXP(3,7))
+            .put(Material.DEEPSLATE_DIAMOND_ORE, new OreXP(3,7))
+            .put(Material.EMERALD_ORE, new OreXP(3,7))
+            .put(Material.DEEPSLATE_EMERALD_ORE, new OreXP(3,7))
+            .put(Material.LAPIS_ORE, new OreXP(2,5))
+            .put(Material.DEEPSLATE_LAPIS_ORE, new OreXP(2,5))
+            .put(Material.NETHER_QUARTZ_ORE, new OreXP(2,5))
+            .put(Material.REDSTONE_ORE, new OreXP(1,5))
+            .put(Material.DEEPSLATE_REDSTONE_ORE, new OreXP(1,5));
+
+    public static final ImmutableMap<Material, OreXP> ORES_XP = ORES_XP_raw.build();
+
+    public static class OreXP {
+        private final int minXP;
+        private final int maxXP;
+
+        public OreXP(int minXP, int maxXP) {
+            this.minXP = minXP;
+            this.maxXP = maxXP;
+        }
+
+        public int getMinXP() {
+            return minXP;
+        }
+
+        public int getMaxXP() {
+            return maxXP;
+        }
+    }
 
     @Override
     public void onEnable() {

--- a/src/main/java/me/otavio/treefella/listeners/BlockBreakEvent.java
+++ b/src/main/java/me/otavio/treefella/listeners/BlockBreakEvent.java
@@ -7,12 +7,16 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Objects;
+import java.util.Random;
 
 public class BlockBreakEvent implements Listener {
 
@@ -57,14 +61,44 @@ public class BlockBreakEvent implements Listener {
                 )
             ) && !isPlayerPlacedBlock && p.isSneaking()
         ) {
-            this.checkNearbyBlocks(b, p);
+            this.checkNearbyBlocks(b, p, e);
+
+            // Grant experience orbs
+            OreXP oreXP = TreeFella.ORES_XP.get(b.getType());
+            if (oreXP != null) {
+                int xp = oreXP.getRandomXP();
+                ExperienceOrb expOrb = b.getWorld().spawn(b.getLocation(), ExperienceOrb.class);
+                expOrb.setExperience(xp);
+            }
+
+            // Apply fortune enchantment
+            if (itemInHand.containsEnchantment(org.bukkit.enchantments.Enchantment.LOOT_BONUS_BLOCKS)) {
+                int fortuneLevel = itemInHand.getEnchantmentLevel(org.bukkit.enchantments.Enchantment.LOOT_BONUS_BLOCKS);
+                // Adjust drops based on fortune level
+                e.setDropItems(false);
+                for (ItemStack drop : b.getDrops(itemInHand)) {
+                    int amount = drop.getAmount() + (int) (Math.random() * (fortuneLevel + 1));
+                    drop.setAmount(amount);
+                    b.getWorld().dropItemNaturally(b.getLocation(), drop);
+                }
+            }
+
+            // Apply unbreaking enchantment
+            if (itemInHand.containsEnchantment(org.bukkit.enchantments.Enchantment.DURABILITY)) {
+                int unbreakingLevel = itemInHand.getEnchantmentLevel(org.bukkit.enchantments.Enchantment.DURABILITY);
+                if (Math.random() < 1.0 / (unbreakingLevel + 1)) {
+                    Damageable itemMeta = (Damageable) itemInHand.getItemMeta();
+                    itemMeta.setDamage(itemMeta.getDamage() + 1);
+                    itemInHand.setItemMeta((ItemMeta) itemMeta);
+                }
+            }
 
         } else if (isPlayerPlacedBlock && TreeFella.LOGS.contains(b.getType())) {
             PlacedBlocks.get().set(path, null);
         }
     }
 
-    public void checkNearbyBlocks(Block block, Player player) {
+    public void checkNearbyBlocks(Block block, Player player, org.bukkit.event.block.BlockBreakEvent e) {
         int x = -1;
         int y = -1;
         int z = -1;
@@ -84,7 +118,23 @@ public class BlockBreakEvent implements Listener {
                     if (TreeFella.LOGS.contains(nearbyBlock.getType()) || TreeFella.ORES.contains(nearbyBlock.getType())) {
                         ItemStack tool = player.getInventory().getItemInMainHand();
 
-                        nearbyBlock.breakNaturally(tool);
+                        // Apply Fortune enchantment
+                        int fortuneLevel = tool.getEnchantmentLevel(org.bukkit.enchantments.Enchantment.LOOT_BONUS_BLOCKS);
+                        int dropMultiplier = 1 + new Random().nextInt(fortuneLevel + 1);
+
+                        if (TreeFella.ORES_XP.containsKey(nearbyBlock.getType())) {
+                            int minXP = Objects.requireNonNull(TreeFella.ORES_XP.get(nearbyBlock.getType())).getMinXP();
+                            int maxXP = Objects.requireNonNull(TreeFella.ORES_XP.get(nearbyBlock.getType())).getMaxXP();
+
+                            int xp = (int) (Math.random() * (maxXP - minXP + 1)) + minXP;
+
+                            ExperienceOrb orb = e.getPlayer().getWorld().spawn(nearbyBlock.getLocation(), ExperienceOrb.class);
+                            orb.setExperience(xp);
+                        }
+
+                        for (int d = 0; d < dropMultiplier; d++) {
+                            nearbyBlock.breakNaturally(tool);
+                        }
 
                         int toolDurability = tool.getType().getMaxDurability();
 
@@ -93,7 +143,11 @@ public class BlockBreakEvent implements Listener {
                         Damageable dmg = (Damageable) meta;
 
                         if (dmg != null && dmg.getDamage() <= toolDurability) {
-                            dmg.setDamage(dmg.getDamage() + 1);
+                            // Apply Unbreaking enchantment
+                            int unbreakingLevel = tool.getEnchantmentLevel(org.bukkit.enchantments.Enchantment.DURABILITY);
+                            if (unbreakingLevel == 0 || new Random().nextInt(unbreakingLevel + 1) == 0) {
+                                dmg.setDamage(dmg.getDamage() + 1);
+                            }
 
                             tool.setItemMeta(dmg);
 
@@ -104,7 +158,7 @@ public class BlockBreakEvent implements Listener {
                             break outerLoop;
                         }
 
-                        this.checkNearbyBlocks(nearbyBlock, player);
+                        this.checkNearbyBlocks(nearbyBlock, player, e);
 
                     }
 

--- a/src/main/java/me/otavio/treefella/listeners/BlockBreakEvent.java
+++ b/src/main/java/me/otavio/treefella/listeners/BlockBreakEvent.java
@@ -63,36 +63,6 @@ public class BlockBreakEvent implements Listener {
         ) {
             this.checkNearbyBlocks(b, p, e);
 
-            // Grant experience orbs
-            OreXP oreXP = TreeFella.ORES_XP.get(b.getType());
-            if (oreXP != null) {
-                int xp = oreXP.getRandomXP();
-                ExperienceOrb expOrb = b.getWorld().spawn(b.getLocation(), ExperienceOrb.class);
-                expOrb.setExperience(xp);
-            }
-
-            // Apply fortune enchantment
-            if (itemInHand.containsEnchantment(org.bukkit.enchantments.Enchantment.LOOT_BONUS_BLOCKS)) {
-                int fortuneLevel = itemInHand.getEnchantmentLevel(org.bukkit.enchantments.Enchantment.LOOT_BONUS_BLOCKS);
-                // Adjust drops based on fortune level
-                e.setDropItems(false);
-                for (ItemStack drop : b.getDrops(itemInHand)) {
-                    int amount = drop.getAmount() + (int) (Math.random() * (fortuneLevel + 1));
-                    drop.setAmount(amount);
-                    b.getWorld().dropItemNaturally(b.getLocation(), drop);
-                }
-            }
-
-            // Apply unbreaking enchantment
-            if (itemInHand.containsEnchantment(org.bukkit.enchantments.Enchantment.DURABILITY)) {
-                int unbreakingLevel = itemInHand.getEnchantmentLevel(org.bukkit.enchantments.Enchantment.DURABILITY);
-                if (Math.random() < 1.0 / (unbreakingLevel + 1)) {
-                    Damageable itemMeta = (Damageable) itemInHand.getItemMeta();
-                    itemMeta.setDamage(itemMeta.getDamage() + 1);
-                    itemInHand.setItemMeta((ItemMeta) itemMeta);
-                }
-            }
-
         } else if (isPlayerPlacedBlock && TreeFella.LOGS.contains(b.getType())) {
             PlacedBlocks.get().set(path, null);
         }
@@ -118,10 +88,6 @@ public class BlockBreakEvent implements Listener {
                     if (TreeFella.LOGS.contains(nearbyBlock.getType()) || TreeFella.ORES.contains(nearbyBlock.getType())) {
                         ItemStack tool = player.getInventory().getItemInMainHand();
 
-                        // Apply Fortune enchantment
-                        int fortuneLevel = tool.getEnchantmentLevel(org.bukkit.enchantments.Enchantment.LOOT_BONUS_BLOCKS);
-                        int dropMultiplier = 1 + new Random().nextInt(fortuneLevel + 1);
-
                         if (TreeFella.ORES_XP.containsKey(nearbyBlock.getType())) {
                             int minXP = Objects.requireNonNull(TreeFella.ORES_XP.get(nearbyBlock.getType())).getMinXP();
                             int maxXP = Objects.requireNonNull(TreeFella.ORES_XP.get(nearbyBlock.getType())).getMaxXP();
@@ -131,10 +97,8 @@ public class BlockBreakEvent implements Listener {
                             ExperienceOrb orb = e.getPlayer().getWorld().spawn(nearbyBlock.getLocation(), ExperienceOrb.class);
                             orb.setExperience(xp);
                         }
-
-                        for (int d = 0; d < dropMultiplier; d++) {
-                            nearbyBlock.breakNaturally(tool);
-                        }
+                        
+						nearbyBlock.breakNaturally(tool);
 
                         int toolDurability = tool.getType().getMaxDurability();
 


### PR DESCRIPTION
Closes #6
Closes #7

Adds a spawn of XP orbs and the missing log type in the immutable list.
Updated Paper to 1.21.5-r0 snapshot.

-- Copliot summary below --

Add logic to grant EXP and a missing log type

* Modify `src/main/java/me/otavio/treefella/TreeFella.java` to include a new `ImmutableMap` for ores and their corresponding EXP values.
* Add a new `OreXP` class to handle the minimum and maximum EXP values for each ore.
* Update `src/main/java/me/otavio/treefella/listeners/BlockBreakEvent.java` to grant EXP orbs when ores are vein mined.
* Update the `checkNearbyBlocks` method in `BlockBreakEvent.java` to handle EXP drops and enchantments for nearby blocks.
* Update the LOGS immutable list with a new log type.
* Update `pom.xml` to use a newer version of the `paper-api` dependency.